### PR TITLE
Remove crds completely after downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.co
 ## License
 
 External Secrets Operator is under Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
+
+*Note: This Helm Operator will deploy ESO (when you create the OperatorConfig) without the CRDs. With OLM this is not a problem since OLM manages and deploys the CRDs. If for some reason you plan to use this helm operator without OLM, you need to apply the ESO CRDs to you cluster at some point.*

--- a/hack/download-helm-chart.sh
+++ b/hack/download-helm-chart.sh
@@ -13,3 +13,5 @@ else
   rm -rf ${HELM_CHART_PATH}/*
   curl -sL ${REPO}/releases/download/helm-chart-${HELM_CHART_VERSION}/external-secrets-${HELM_CHART_VERSION}.tgz | tar xz -C helm-charts/
 fi
+sed -i "s|installCRDs: [^ ]*|installCRDs: false|g" ${HELM_CHART_PATH}/values.yaml
+rm -rf ${HELM_CHART_PATH}/templates/crds


### PR DESCRIPTION
I tried multiple ways to force `installCRDs: false` but they always get installed by the chart watcher/applier.

Decided to just remove crds as the end step of the download script. This way OLM will create the crds and this helm operator will just deploy ESO