### PR TITLE
Feature: automate operatorhub release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,14 +165,8 @@ bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
 .PHONY: bundle-operatorhub
-bundle-operatorhub: ## Add the bundle to community-operators repo
-	@rm -rf community-operators || true
-	git clone https://github.com/k8s-operatorhub/community-operators
-	cp -r bundle community-operators/operators/external-secrets-operator/$(VERSION)
-	cd community-operators && \
-		operator-sdk bundle validate ./operators/external-secrets-operator/$(VERSION) --select-optional suite=operatorframework && \
-		git checkout -b feature/external-secrets-$(VERSION)
-	@echo -e "now go to repo, commit changes, push and open a PR \n> cd community-operators\n> git add . && git commit -s -m \"chore: bump external secrets $(VERSION)\" "
+bundle-operatorhub: ## Add the bundle to all community-operators repos
+	./hack/bundle-operatorhub.sh $(VERSION)
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/config/samples/external_secret.yaml
+++ b/config/samples/external_secret.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     acme.org/owned-by: "q-team"
   annotations:
-    acme.org/sha: 1234
+    acme.org/sha: "1234"
 
 spec:
 

--- a/hack/bundle-operatorhub.sh
+++ b/hack/bundle-operatorhub.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+# this script is used to:
+# (1) sync upstream operatorhub/openshift operators
+#     repositories with our fork
+# (2) automate the release worklflow with the above repositories
+VERSION=$1
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$SCRIPT_DIR/../
+BUNDLE_DIR="$REPO_ROOT/bundle"
+
+COMMUNITY_UPSTREAM="https://github.com/k8s-operatorhub/community-operators"
+COMMUNITY_FORK="git@github.com:external-secrets/community-operators.git"
+COMMUNITY_DIRNAME=$(basename $COMMUNITY_UPSTREAM)
+
+OPENSHIFT_UPSTREAM="https://github.com/redhat-openshift-ecosystem/community-operators-prod"
+OPENSHIFT_FORK="git@github.com:external-secrets/community-operators-prod.git"
+OPENSHIFT_DIRNAME=$(basename $OPENSHIFT_UPSTREAM)
+
+if ! command -v hub &> /dev/null
+then
+    echo "hub could not be found"
+    echo "see here for instructions: https://github.com/github/hub#installation"
+    exit
+fi
+
+function main() {
+  sync_repo ${COMMUNITY_UPSTREAM} ${COMMUNITY_FORK} ${COMMUNITY_DIRNAME}
+  sync_repo ${OPENSHIFT_UPSTREAM} ${OPENSHIFT_FORK} ${OPENSHIFT_DIRNAME}
+}
+
+function sync_repo() {
+  REPO=$1
+  FORK=$2
+  DIRNAME=$3
+  BRANCH_NAME=bump-release-${VERSION}
+  OWNER=$(basename $(dirname $REPO))
+
+  TMP=$(mktemp -d)
+  echo "workdir: ${TMP}"
+  cd ${TMP}
+
+  # The remote names follow a specific convention.
+  # see here: https://hub.github.com/hub.1.html#conventions
+  git clone -o upstream $REPO $DIRNAME
+  cd $DIRNAME
+  git remote add origin $FORK
+  git push origin main
+  git checkout -b ${BRANCH_NAME}
+
+  cp -Tr ${BUNDLE_DIR} \
+    ./operators/external-secrets-operator/${VERSION}
+
+  if [[ -z $(git status --porcelain=v1 2>/dev/null) ]]; then
+    echo "no changes detected. skipping"
+  fi
+
+  operator-sdk bundle validate \
+    ./operators/external-secrets-operator/${VERSION} \
+    --select-optional suite=operatorframework
+
+  git add .
+  git commit -s -m "chore: bump external secrets ${VERSION}"
+  git push origin ${BRANCH_NAME} --force
+
+  hub pull-request -o \
+    -m "bump external-secrets operator ${VERSION}" \
+    -m "bump external-secrets-operator ${VERSION}" \
+    -b ${OWNER}:main \
+    -h external-secrets:${BRANCH_NAME}
+
+  rm -rf ${TMP}
+}
+
+main $@


### PR DESCRIPTION
The release process is partly manual and error-prone right now. I want to automate a couple of more things:

1. automate workflow for both `community-operators` AND `community-operators-prod`
2. automatically commit, push and open PR
3. the last remaining manual thing to do is to wait for CI in the respective repository
 

relates to: https://github.com/external-secrets/external-secrets/issues/746