### PR TITLE
fix: add missing permission for servicemonitor

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -126,4 +126,14 @@ rules:
   verbs:
   - '*'
 
+# Rules to allow serviceMonitor access
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+
 #+kubebuilder:scaffold:rules


### PR DESCRIPTION
This is to address the permission error ecountered when enabling serviceMonitor. 
```
"error": "failed to get candidate release: rendered manifests contain a resource that already exists. 
Unable to continue with update: could not get information about the resource: servicemonitors.monitoring.coreos.com 
\"external-secrets-operator-config-metrics\" is forbidden: 
User \"system:serviceaccount:external-secrets-operator:external-secrets-operator-controller-manager\" cannot get resource 
\"servicemonitors\" in API group \"monitoring.coreos.com\" in the namespace \"external-secrets-operator\"",
"stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:227"
}
```
After our investigation, we discovered that the ClusterRole created by OLM does not have sufficient permission to access serviceMonitor API. This PR is to add the missing permissions.