### PR TITLE
Add missed verbs for serviceMonitor API

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,8 +132,10 @@ rules:
   resources:
   - servicemonitors
   verbs:
-  - get
   - create
+  - get
+  - list
   - update
+  - watch
 
 #+kubebuilder:scaffold:rules


### PR DESCRIPTION
Apologize for the sloppiness. We missed `list` and `watch` verbs from last PR. They are required for ESO to access serviceMonitor.

Signed-off-by: Tom Chen <tomking.chen@gmail.com>