### PR TITLE
Add additional permission for serviceMonitor

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -133,8 +133,10 @@ rules:
   - servicemonitors
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
   - update
   - watch
 


### PR DESCRIPTION
Hey, @gusfcarvalho @moolen turns out we need more verbs to add to the clusterRole for serviceMonitor to work. Can you add this to the next release? Thanks.

Signed-off-by: Tom Chen <tomking.chen@gmail.com>