### PR TITLE
inform the necessity of the OperatorConfig resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A Kubernetes Operator based on the Operator SDK (Helm version) to configure **[official external-secrets operator helm chart](https://github.com/external-secrets/external-secrets)**, so it can be installed via OLM without having to do any change on current Helm Charts.
 
+Before any other resources provided by this Operator can be deployed, it is essential to create an OperatorConfig resource.
+
 The usual Helm Chart file `values.yaml`, like:
 ```yaml
 prometheus:
@@ -22,7 +24,7 @@ resources:
      memory: 256Mi
 ```
 
-Need to be encapsulated into a new custom resource called `OperatorConfig`:
+needs to be encapsulated into a new custom resource called `OperatorConfig`:
 ```yaml
 apiVersion: operator.external-secrets.io/v1alpha1
 kind: OperatorConfig
@@ -42,7 +44,7 @@ spec:
      memory: 256Mi
 ```
 
-So the operator will create all helm chart resources, using the custom resource name as a preffix for all resources names, like for example a `Deployment` called `cluster-external-secrets`.
+Once the OperatorConfig resource is deployed, the operator will create all helm chart resources, using the custom resource name as a preffix for all resources names, like for example a `Deployment` called `cluster-external-secrets`.
 
 ## Initial bootstrap
 

--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -748,6 +748,9 @@ spec:
   description: |
     A Kubernetes Operator based on the Operator SDK (Helm version) to configure **[official external-secrets operator helm chart](https://github.com/external-secrets/external-secrets)**, so it can be installed via OLM without having to do any change on current Helm Charts.
 
+    Before any other resources provided by this Operator can be deployed, it is essential to create an
+    OperatorConfig resource.
+
     The usual Helm Chart file `values.yaml`, like:
     ```yaml
     prometheus:
@@ -763,7 +766,7 @@ spec:
          memory: 256Mi
     ```
 
-    Need to be encapsulated into a new custom resource called `OperatorConfig`:
+    need to be encapsulated into a new custom resource called `OperatorConfig`:
     ```yaml
     apiVersion: operator.external-secrets.io/v1alpha1
     kind: OperatorConfig
@@ -783,7 +786,7 @@ spec:
          memory: 256Mi
     ```
 
-    So the operator will create all helm chart resources, using the custom resource name as a preffix for all resources names, like for example a `Deployment` called `cluster-external-secrets`.
+    Once the OperatorConfig resource is deployed, the operator will create all helm chart resources, using the custom resource name as a preffix for all resources names, like for example a `Deployment` called `cluster-external-secrets`.
 
     ## Documentation
 


### PR DESCRIPTION
Issue came up when the user deploys a version v1alpha1 manifest. Without the OperatorConfig resource, the resource can not automatically change to v1beta1 because the OperatorConfig deploys the conversion webhook to upgrade v1alpha1 to v1beta1.