### PR TITLE
fix: reset runAsUser to not interfere with SCCs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,5 +16,8 @@ jobs:
           path: ./bin
           key: ${{ runner.os }}-bin
 
+      - name: Build image
+        run: make docker-build
+
       - name: Run test-e2e
         run: make test-e2e

--- a/hack/download-helm-chart.sh
+++ b/hack/download-helm-chart.sh
@@ -22,5 +22,8 @@ rm -rf ${HELM_CHART_PATH}/templates/crds
 # 2: reset runAsUser due to SCCs blocking runAsUser
 # see: https://github.com/external-secrets/external-secrets/issues/2342
 yq e -i '.securityContext.runAsUser = null' ${HELM_CHART_PATH}/values.yaml
+yq e -i '.securityContext.seccompProfile = null' ${HELM_CHART_PATH}/values.yaml
 yq e -i '.webhook.securityContext.runAsUser = null' ${HELM_CHART_PATH}/values.yaml
+yq e -i '.webhook.securityContext.seccompProfile = null' ${HELM_CHART_PATH}/values.yaml
 yq e -i '.certController.securityContext.runAsUser = null' ${HELM_CHART_PATH}/values.yaml
+yq e -i '.certController.securityContext.seccompProfile = null' ${HELM_CHART_PATH}/values.yaml


### PR DESCRIPTION
Working towards: https://github.com/external-secrets/external-secrets/issues/2342

This PR patches the helm values and resets `runAsUser` to null to not interfere with SCCs. 
OpenShift rejects ESO pods because it defines a `runAsUser` from `v0.8.2` onwards. This should not be the case, hence we're patching it specifically for OpenShift.