### PR TITLE
Upgrade operator-sdk-helm 1.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.15.0
+FROM quay.io/operator-framework/helm-operator:v1.32.0
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ ifeq (,$(shell which helm-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(HELM_OPERATOR)) ;\
-	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/helm-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/helm-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(HELM_OPERATOR) ;\
 	}
 else
@@ -226,7 +226,7 @@ catalog-push: ## Push a catalog image.
 #############################################
 
 # Download operator-sdk binary if necessary
-OPERATOR_SDK_RELEASE = v1.19.0
+OPERATOR_SDK_RELEASE = v1.32.0
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk-$(OPERATOR_SDK_RELEASE)
 OPERATOR_SDK_DL_URL = https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_RELEASE)/operator-sdk_$(OS)_$(ARCH)
 operator-sdk:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.9.4
+VERSION ?= 0.9.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -671,7 +671,7 @@ metadata:
     capabilities: Deep Insights
     categories: Security
     certified: "false"
-    containerImage: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.4
+    containerImage: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.5
     createdAt: "2021-11-22 00:00:00"
     description: Operator to configure external-secrets helm-chart based operator
     operatorframework.io/cluster-monitoring: "true"
@@ -682,7 +682,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: external-secrets-operator.v0.9.4
+  name: external-secrets-operator.v0.9.5
   namespace: external-secrets
 spec:
   apiservicedefinitions: {}
@@ -968,7 +968,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.4
+                image: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1066,4 +1066,4 @@ spec:
   provider:
     name: External Secrets
     url: https://external-secrets.io
-  version: 0.9.4
+  version: 0.9.5

--- a/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: clusterexternalsecrets.external-secrets.io
 spec:
@@ -514,6 +514,10 @@ spec:
                   - type
                   type: object
                 type: array
+              externalSecretName:
+                description: ExternalSecretName is the name of the ExternalSecrets
+                  created by the ClusterExternalSecret
+                type: string
               failedNamespaces:
                 description: Failed namespaces are the namespaces that failed to apply
                   an ExternalSecret

--- a/bundle/manifests/external-secrets.io_clustersecretstores.yaml
+++ b/bundle/manifests/external-secrets.io_clustersecretstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: clustersecretstores.external-secrets.io
 spec:

--- a/bundle/manifests/external-secrets.io_externalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_externalsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: externalsecrets.external-secrets.io
 spec:

--- a/bundle/manifests/external-secrets.io_pushsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_pushsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: pushsecrets.external-secrets.io
 spec:
@@ -78,6 +78,11 @@ spec:
                       - remoteRef
                       - secretKey
                       type: object
+                    metadata:
+                      description: Metadata is metadata attached to the secret. The
+                        structure of metadata is provider specific, please look it
+                        up in the provider documentation.
+                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - match
                   type: object
@@ -230,6 +235,11 @@ spec:
                         - remoteRef
                         - secretKey
                         type: object
+                      metadata:
+                        description: Metadata is metadata attached to the secret.
+                          The structure of metadata is provider specific, please look
+                          it up in the provider documentation.
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                     - match
                     type: object

--- a/bundle/manifests/external-secrets.io_secretstores.yaml
+++ b/bundle/manifests/external-secrets.io_secretstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: secretstores.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: acraccesstokens.generators.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: ecrauthorizationtokens.generators.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_fakes.yaml
+++ b/bundle/manifests/generators.external-secrets.io_fakes.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: fakes.generators.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: gcraccesstokens.generators.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_passwords.yaml
+++ b/bundle/manifests/generators.external-secrets.io_passwords.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: passwords.generators.external-secrets.io
 spec:

--- a/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: vaultdynamicsecrets.generators.external-secrets.io
 spec:

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/external-secrets/external-secrets-helm-operator
-  newTag: v0.9.4
+  newTag: v0.9.5

--- a/config/manifests/bases/external-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-secrets-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Deep Insights
     categories: Security
     certified: "false"
-    containerImage: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.4
+    containerImage: ghcr.io/external-secrets/external-secrets-helm-operator:v0.9.5
     createdAt: "2021-11-22 00:00:00"
     description: Operator to configure external-secrets helm-chart based operator
     operatorframework.io/cluster-monitoring: "true"

--- a/config/manifests/crds/acraccesstoken.yml
+++ b/config/manifests/crds/acraccesstoken.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: acraccesstokens.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/manifests/crds/clusterexternalsecret.yml
+++ b/config/manifests/crds/clusterexternalsecret.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterexternalsecrets.external-secrets.io
 spec:
   group: external-secrets.io
@@ -426,6 +426,9 @@ spec:
                       - type
                     type: object
                   type: array
+                externalSecretName:
+                  description: ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+                  type: string
                 failedNamespaces:
                   description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
                   items:

--- a/config/manifests/crds/clustersecretstore.yml
+++ b/config/manifests/crds/clustersecretstore.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clustersecretstores.external-secrets.io
 spec:
   group: external-secrets.io

--- a/config/manifests/crds/ecrauthorizationtoken.yml
+++ b/config/manifests/crds/ecrauthorizationtoken.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: ecrauthorizationtokens.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/manifests/crds/externalsecret.yml
+++ b/config/manifests/crds/externalsecret.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: externalsecrets.external-secrets.io
 spec:
   group: external-secrets.io

--- a/config/manifests/crds/fake.yml
+++ b/config/manifests/crds/fake.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: fakes.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/manifests/crds/gcraccesstoken.yml
+++ b/config/manifests/crds/gcraccesstoken.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: gcraccesstokens.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/manifests/crds/password.yml
+++ b/config/manifests/crds/password.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: passwords.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/manifests/crds/pushsecret.yml
+++ b/config/manifests/crds/pushsecret.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: pushsecrets.external-secrets.io
 spec:
   group: external-secrets.io
@@ -63,6 +63,9 @@ spec:
                           - remoteRef
                           - secretKey
                         type: object
+                      metadata:
+                        description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                       - match
                     type: object
@@ -191,6 +194,9 @@ spec:
                             - remoteRef
                             - secretKey
                           type: object
+                        metadata:
+                          description: Metadata is metadata attached to the secret. The structure of metadata is provider specific, please look it up in the provider documentation.
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                         - match
                       type: object

--- a/config/manifests/crds/secretstore.yml
+++ b/config/manifests/crds/secretstore.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: secretstores.external-secrets.io
 spec:
   group: external-secrets.io

--- a/config/manifests/crds/vaultdynamicsecret.yml
+++ b/config/manifests/crds/vaultdynamicsecret.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: vaultdynamicsecrets.generators.external-secrets.io
 spec:
   group: generators.external-secrets.io

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
     labels:
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
The last operator-sdk helm controller integrates an optimization on kubernetes secrets, which reduce drastically the memory consumption of the helm controller on huge cluster with many secrets.

It fixes the following issue [#2755](https://github.com/external-secrets/external-secrets/issues/2755) in external-secrets repository.

Could you check it and merge it ?
